### PR TITLE
Fix stringifyFloat appending .0 to scientific notation values

### DIFF
--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -75,7 +75,7 @@ function stringifyLong(value: LongTag): string {
 }
 
 function stringifyFloat(value: number | FloatTag): string {
-  return `${value.valueOf()}${Number.isInteger(value.valueOf()) ? ".0" : ""}f`;
+  return `${value.valueOf()}${Number.isInteger(value.valueOf()) && !String(value.valueOf()).includes("e") ? ".0" : ""}f`;
 }
 
 function stringifyDouble(value: DoubleTag): string {


### PR DESCRIPTION
`Number.isInteger(3.4028234663852886e+38)` returns `true`, so large floats stringify as `3.4028234663852886e+38.0f`. But the parser doesn't handle that, it reads it as an unquoted string rather than a float, silently producing a `TAG_String`.

Fix is to skip the `.0` suffix when the value is already in scientific notation, the same as `stringifyDouble` already does.

Practical impact: Bedrock uses `Float.MAX_VALUE` as the "no limit" sentinel in every entity Attribute's `Max`/`DefaultMax`. Found this while editing player data directly in a Bedrock world's LevelDB — any round-trip through `stringify` → `parse` → `write` corrupts those fields from TAG_Float to TAG_String, which in-game clamps movement speed to 0.

```diff
 minecraft:movement {
   Base: 0.10000000149011612f,
   Current: 0.10000000149011612f,
-  DefaultMax: 3.4028234663852886e+38.0f,
-  Max: 3.4028234663852886e+38.0f,
+  DefaultMax: 3.4028234663852886e+38f,
+  Max: 3.4028234663852886e+38f,
   DefaultMin: 0.0f,
   Min: 0.0f
 }
```